### PR TITLE
archive this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # W3C WebDriver Protocol Examples
-This repository contains language binding examples for the new Selenium 4 [W3C WebDriver protocol](https://saucelabs.com/products/open-source-frameworks/selenium/w3c-webdriver-protocol) and how to execute those tests on [saucelabs.com](www.saucelabs.com). 
 
-Each example also leverages the new `sauce:options` capability. For more information visit the [Sauce Labs W3C Support Documentation](https://wiki.saucelabs.com/display/DOCS/Selenium+W3C+Capabilities+Support) page
+## THIS REPO HAS BEEN DEPRECATED
+
+Check out the latest [Selenium 4 Code Examples](https://docs.saucelabs.com/web-apps/automated-testing/selenium/#), which include specific
+links to the respective [SauceLabs Training Demo Repos](https://github.com/saucelabs-training#choose-pinned-repositories).
+
+This code is provided on an "AS-IS” basis without warranty of any kind, either express or implied, including without limitation any implied warranties of condition, uninterrupted use, merchantability, fitness for a particular purpose, or non-infringement. Your tests and testing environments may require you to modify this framework. Issues regarding this framework should be submitted through GitHub. For questions regarding Sauce Labs integration, please see the Sauce Labs documentation at https://wiki.saucelabs.com/. This framework is not maintained by Sauce Labs Support.


### PR DESCRIPTION
We now have (or will have) better, up to date examples in our docs / demo-<language> repos.

What do you think we move this to https://github.com/sauce-archives/ ?